### PR TITLE
Use FaunaDB and make things collaborative and shared in real-time

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,12 @@ It comes with the following features:
 - **Selection** of nodes and edges, one at a time 
 - Uses **`Recoil`** for shared state management
 - Automatically re-calculate the **height** of nodes when jumping lines in `textarea`
-- Graph data (nodes, edges) are **persisted** in the browser **localstorage** and loaded upon page reload
+- ~~Graph data (nodes, edges) are **persisted** in the browser **localstorage** and automatically loaded upon page reload~~
+  - Graph data (nodes, edges) are **persisted** in FaunaDB and automatically loaded upon page reload
+- Real-time support for collaboration (open 2 tabs), using FaunaDB
+  - FaunaDB token is public and has read/update access rights on one table of the DB only
+  - All users share the same "Canvas" document in the DB
+  - This POC will **not improve further** the collaborative experience, it's only a POC (undo/redo undoes peer actions, undo/redo seems a bit broken sometimes)
 
 Known limitations:
 - Editor direction is `RIGHT` (hardcoded) and adding nodes will add them to the right side, always (even if you change the direction)

--- a/examples/index.html
+++ b/examples/index.html
@@ -1,0 +1,59 @@
+<html>
+  <head>
+    <style>
+      span.scores {
+        font-family: monospace;
+        white-space: pre;
+      }
+    </style>
+  </head>
+  <body>
+    <h1>Scores stream</h1>
+    <p>
+      Scores: <span class="scores"></span>
+    </p>
+  </body>
+
+  <script src="https://cdn.jsdelivr.net/npm/faunadb@latest/dist/faunadb-min.js"></script>
+  <script type="text/javascript">
+
+    var faunadb = window.faunadb;
+    var q = faunadb.query;
+
+    var client = new faunadb.Client({
+      secret: 'fnAEDdp0CWACBZUTQvkktsqAQeW03uDhZYY0Ttlg',
+    });
+
+    var docRef = q.Ref(q.Collection('Scores'), '1');
+
+    function report(e) {
+      console.log(e);
+      var data = ('action' in e)
+        ? e['document'].data
+        : e.data;
+      document.body.innerHTML += '<p><span class="scores">' +
+        JSON.stringify(data) +
+        '</span></p>';
+    }
+
+    var stream;
+    const startStream = () => {
+      stream = client.stream.document(docRef)
+        .on('snapshot', snapshot => {
+          report(snapshot);
+        })
+        .on('version', version => {
+          report(version);
+        })
+        .on('error', error => {
+          console.log('Error:', error);
+          stream.close();
+          setTimeout(startStream, 1000);
+        })
+        .start();
+    };
+
+    startStream();
+
+  </script>
+</html>

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "@welldone-software/why-did-you-render": "6.0.5",
     "animate.css": "4.1.1",
     "classnames": "2.2.6",
+    "faunadb": "4.1.1",
     "framer-motion": "3.2.1",
     "lodash.capitalize": "4.2.1",
     "lodash.clonedeep": "4.5.0",

--- a/src/components/editor/CanvasContainer.tsx
+++ b/src/components/editor/CanvasContainer.tsx
@@ -16,6 +16,7 @@ import {
   useUndo,
 } from 'reaflow';
 import { useRecoilState } from 'recoil';
+import { updateSharedCanvasDocument } from '../../lib/faunadbClient';
 import settings from '../../settings';
 import { blockPickerMenuSelector } from '../../states/blockPickerMenuState';
 import { canvasDatasetSelector } from '../../states/canvasDatasetSelector';
@@ -29,7 +30,6 @@ import {
   createNodeFromDefaultProps,
   getDefaultNodePropsWithFallback,
 } from '../../utils/nodes';
-import { persistCanvasDatasetInLS } from '../../utils/persistCanvasDataset';
 import canvasUtilsContext from '../context/canvasUtilsContext';
 import BaseEdge from '../edges/BaseEdge';
 import NodeRouter from '../nodes/NodeRouter';
@@ -80,12 +80,13 @@ const CanvasContainer: React.FunctionComponent<Props> = (props): JSX.Element | n
   const [cursorXY, setCursorXY] = useState<[number, number]>([0, 0]);
 
   /**
-   * When nodes or edges are modified, updates the persisted data in the local storage.
+   * When nodes or edges are modified, updates the persisted data in FaunaDB.
    *
    * Persisted data are automatically loaded upon page refresh.
    */
   useEffect(() => {
-    persistCanvasDatasetInLS(canvasDataset);
+    // persistCanvasDatasetInLS(canvasDataset);
+    updateSharedCanvasDocument(canvasDataset);
   }, [canvasDataset]);
 
   /**

--- a/src/lib/faunadbClient.ts
+++ b/src/lib/faunadbClient.ts
@@ -1,0 +1,29 @@
+import faunadb from 'faunadb';
+import { Subscription } from 'faunadb/src/types/Stream';
+
+const client = new faunadb.Client({ secret: 'fnAEDdp0CWACBZUTQvkktsqAQeW03uDhZYY0Ttlg' });
+
+var q = faunadb.query;
+var docRef = q.Ref(q.Collection('Scores'), '1');
+
+let stream: Subscription;
+
+const startStream = () => {
+  stream = client.stream.
+    // @ts-ignore
+    document(docRef)
+    .on('snapshot', (snapshot: any) => {
+      console.log(snapshot);
+    })
+    .on('version', (version: any) => {
+      console.log(version);
+    })
+    .on('error', (error: any) => {
+      console.log('Error:', error);
+      stream.close();
+      setTimeout(startStream, 1000);
+    })
+    .start();
+};
+
+startStream();

--- a/src/lib/faunadbClient.ts
+++ b/src/lib/faunadbClient.ts
@@ -1,29 +1,79 @@
-import faunadb from 'faunadb';
+import faunadb, {
+  Create,
+  Expr,
+} from 'faunadb';
 import { Subscription } from 'faunadb/src/types/Stream';
+import * as Fauna from 'faunadb/src/types/values';
+import { CanvasDataset } from '../types/CanvasDataset';
 
+const { Ref, Collection } = faunadb.query;
 const client = new faunadb.Client({ secret: 'fnAEDdp0CWACBZUTQvkktsqAQeW03uDhZYY0Ttlg' });
 
-var q = faunadb.query;
-var docRef = q.Ref(q.Collection('Scores'), '1');
+type CanvasResult = Fauna.values.Document<CanvasDataset>;
 
-let stream: Subscription;
-
-const startStream = () => {
-  stream = client.stream.
-    // @ts-ignore
-    document(docRef)
-    .on('snapshot', (snapshot: any) => {
-      console.log(snapshot);
-    })
-    .on('version', (version: any) => {
-      console.log(version);
-    })
-    .on('error', (error: any) => {
-      console.log('Error:', error);
-      stream.close();
-      setTimeout(startStream, 1000);
-    })
-    .start();
+/**
+ * Find the shared canvas document.
+ *
+ * Always use "1" as document ref id.
+ * There is only one document in the DB, and the same document is shared with all users.
+ */
+export const findSharedCanvasDocument = (id: string = '1') => {
+  return Ref(Collection('Canvas'), id);
 };
 
-startStream();
+/**
+ * Starts the real-time stream between the browser and the FaunaDB database, on a specific record/document.
+ *
+ * @param documentRef
+ * @param onInit
+ */
+export const startStreamOnDocument = (documentRef: Expr, onInit: (snapshot: any) => void) => {
+  let stream: Subscription;
+
+  const _startStream = async (documentRef: Expr) => {
+    console.log(`Stream to FaunaDB is starting for:`, documentRef);
+
+    stream = client.stream.
+      // @ts-ignore
+      document(documentRef)
+      .on('start', (snapshot: any) => {
+        console.log('start', snapshot);
+      })
+      .on('snapshot', (snapshot: any) => {
+        console.log('snapshot', snapshot);
+        onInit(snapshot);
+      })
+      .on('version', (version: any) => {
+        console.log('version', version);
+        onInit(version);
+      })
+      .on('error', async (error: any) => {
+        console.log('Error:', error);
+        if (error?.name === 'NotFound') {
+          const defaultCanvasDataset: CanvasDataset = {
+            nodes: [],
+            edges: [],
+          };
+
+          console.log('No record found, creating record...');
+          const createDefaultRecord = Create(Ref(Collection('Canvas'), '1'), {
+            data: defaultCanvasDataset,
+          });
+          const result: CanvasResult = await client.query(createDefaultRecord);
+          console.log('result', result);
+          onInit(result?.data);
+        } else {
+          stream.close();
+          setTimeout(_startStream, 1000);
+        }
+      })
+      .on('history_rewrite', (error: any) => {
+        console.log('Error:', error);
+        stream.close();
+        setTimeout(_startStream, 1000);
+      })
+      .start();
+  };
+
+  _startStream(documentRef);
+};

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -10,6 +10,7 @@ import { RecoilRoot } from 'recoil';
 import { RecoilDevtools } from '../components/RecoilDevtools';
 import { RecoilExternalStatePortal } from '../components/RecoilExternalStatePortal';
 import '../utils/fontAwesome';
+import '../lib/faunadbClient';
 
 type Props = {
   Component: NextComponentType<NextPageContext>; // Page component, not provided if pageProps.statusCode is 3xx or 4xx

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -10,7 +10,6 @@ import { RecoilRoot } from 'recoil';
 import { RecoilDevtools } from '../components/RecoilDevtools';
 import { RecoilExternalStatePortal } from '../components/RecoilExternalStatePortal';
 import '../utils/fontAwesome';
-import '../lib/faunadbClient';
 
 type Props = {
   Component: NextComponentType<NextPageContext>; // Page component, not provided if pageProps.statusCode is 3xx or 4xx

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -3,10 +3,12 @@ import { useState } from 'react';
 import DisplayOnBrowserMount from '../components/DisplayOnBrowserMount';
 import EditorContainer from '../components/editor/EditorContainer';
 import Layout from '../components/Layout';
+import { setRecoilExternalState } from '../components/RecoilExternalStatePortal';
 import {
   findSharedCanvasDocument,
-  startStreamOnDocument,
+  startStreamingCanvasDataset,
 } from '../lib/faunadbClient';
+import { canvasDatasetSelector } from '../states/canvasDatasetSelector';
 import { CanvasDataset } from '../types/CanvasDataset';
 import { getCanvasDatasetFromLS } from '../utils/persistCanvasDataset';
 
@@ -57,10 +59,12 @@ const IndexPage = (props: any) => {
       setIsLoadingDataFromDB(true);
 
       // Starts the stream between the browser and the FaunaDB using the default canvas document
-      startStreamOnDocument(findSharedCanvasDocument(), (canvasDatasetFromDB: CanvasDataset) => {
+      startStreamingCanvasDataset((canvasDatasetFromDB: CanvasDataset) => {
         console.log('canvasDatasetFromDB', canvasDatasetFromDB);
         setCanvasDataset(canvasDatasetFromDB);
         setIsReadyToRender(true);
+      }, (canvasDatasetRemotelyUpdated: CanvasDataset) => {
+        setRecoilExternalState(canvasDatasetSelector, canvasDatasetRemotelyUpdated);
       });
     }
 

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,7 +1,12 @@
 import { isBrowser } from '@unly/utils';
+import { useState } from 'react';
 import DisplayOnBrowserMount from '../components/DisplayOnBrowserMount';
 import EditorContainer from '../components/editor/EditorContainer';
 import Layout from '../components/Layout';
+import {
+  findSharedCanvasDocument,
+  startStreamOnDocument,
+} from '../lib/faunadbClient';
 import { CanvasDataset } from '../types/CanvasDataset';
 import { getCanvasDatasetFromLS } from '../utils/persistCanvasDataset';
 
@@ -30,7 +35,13 @@ export const getStaticProps = (): { props: Props } => {
  * after it has initialized the global "initialCanvasDataset" browser variable, which is used by the nodesSelector and edgesSelector Recoil state managers.
  */
 const IndexPage = (props: any) => {
-  const { canvasDataset: canvasDatasetFromServer } = props; // We don't use canvasDatasetFromServer in this demo, but localstorage instead
+  const [canvasDataset, setCanvasDataset] = useState<CanvasDataset | undefined>(undefined);
+
+  // Used to know when the app is ready to be rendered (when the data have been fetched from DB)
+  const [isReadyToRender, setIsReadyToRender] = useState<boolean>(false);
+
+  // Used to avoid starting several streams from the same browser
+  const [isLoadingDataFromDB, setIsLoadingDataFromDB] = useState<boolean>(false);
 
   /**
    * Gets the canvas dataset stored in the browser localstorage and makes it available in the global "window" object.
@@ -41,14 +52,34 @@ const IndexPage = (props: any) => {
    *  Also, it's a viable approach whether using the data from browser localstorage, or a real DB.
    */
   if (isBrowser()) {
-    window.initialCanvasDataset = getCanvasDatasetFromLS();
+    // Initialize the stream (only once)
+    if (!isLoadingDataFromDB) {
+      setIsLoadingDataFromDB(true);
+
+      // Starts the stream between the browser and the FaunaDB using the default canvas document
+      startStreamOnDocument(findSharedCanvasDocument(), (canvasDatasetFromDB: CanvasDataset) => {
+        console.log('canvasDatasetFromDB', canvasDatasetFromDB);
+        setCanvasDataset(canvasDatasetFromDB);
+        setIsReadyToRender(true);
+      });
+    }
+
+    if (canvasDataset && setIsReadyToRender) {
+      window.initialCanvasDataset = canvasDataset;
+    }
   }
 
   return (
     <Layout>
       {/* Only renders the EditorContainer on the browser because it's not server-side compatible */}
-      <DisplayOnBrowserMount>
-        <EditorContainer />
+      <DisplayOnBrowserMount
+        deps={[canvasDataset]}
+      >
+        {
+          isReadyToRender && (
+            <EditorContainer />
+          )
+        }
       </DisplayOnBrowserMount>
     </Layout>
   );

--- a/yarn.lock
+++ b/yarn.lock
@@ -1079,7 +1079,7 @@
   dependencies:
     lodash "^4"
 
-abort-controller@3.0.0:
+abort-controller@3.0.0, abort-controller@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/abort-controller/-/abort-controller-3.0.0.tgz#eaf54d53b62bae4138e809ca225c8439a6efb392"
   integrity sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==
@@ -1207,7 +1207,7 @@ base16@^1.0.0:
   resolved "https://registry.yarnpkg.com/base16/-/base16-1.0.0.tgz#e297f60d7ec1014a7a971a39ebc8a98c0b681e70"
   integrity sha1-4pf2DX7BAUp6lxo568ipjAtoHnA=
 
-base64-js@^1.0.2, base64-js@^1.3.1:
+base64-js@^1.0.2, base64-js@^1.2.0, base64-js@^1.3.1:
   version "1.5.1"
   resolved "https://registry.yarnpkg.com/base64-js/-/base64-js-1.5.1.tgz#1b1b440160a5bf7ad40b650f095963481903930a"
   integrity sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==
@@ -1252,6 +1252,13 @@ brorand@^1.0.1, brorand@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/brorand/-/brorand-1.1.0.tgz#12c25efe40a45e3c323eb8675a0a0ce57b22371f"
   integrity sha1-EsJe/kCkXjwyPrhnWgoM5XsiNx8=
+
+browser-detect@^0.2.28:
+  version "0.2.28"
+  resolved "https://registry.yarnpkg.com/browser-detect/-/browser-detect-0.2.28.tgz#5688fc22f638390614ebea4646483403fb20ebfb"
+  integrity sha512-KeWGHqYQmHDkCFG2dIiX/2wFUgqevbw/rd6wNi9N6rZbaSJFtG5kel0HtprRwCGp8sqpQP79LzDJXf/WCx4WAw==
+  dependencies:
+    core-js "^2.5.7"
 
 browserify-aes@^1.0.0, browserify-aes@^1.0.4:
   version "1.2.0"
@@ -1324,6 +1331,11 @@ browserslist@4.16.1:
     electron-to-chromium "^1.3.634"
     escalade "^3.1.1"
     node-releases "^1.1.69"
+
+btoa-lite@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/btoa-lite/-/btoa-lite-1.0.0.tgz#337766da15801210fdd956c22e9c6891ab9d0337"
+  integrity sha1-M3dm2hWAEhD92VbCLpxokaudAzc=
 
 buffer-from@^1.0.0:
   version "1.1.1"
@@ -1529,6 +1541,11 @@ copy-to-clipboard@3.3.1:
   dependencies:
     toggle-selection "^1.0.6"
 
+core-js@^2.5.7:
+  version "2.6.12"
+  resolved "https://registry.yarnpkg.com/core-js/-/core-js-2.6.12.tgz#d9333dfa7b065e347cc5682219d6f690859cc2ec"
+  integrity sha512-Kb2wC0fvsWfQrgk8HU5lW6U/Lcs8+9aaYcy4ZFc6DDlo4nZ7n70dEgE5rtR0oG6ufKDUnrwfWL1mXR5ljDatrQ==
+
 core-util-is@~1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.2.tgz#b5fd54220aa2bc5ab57aab7140c940754503c1a7"
@@ -1576,7 +1593,7 @@ create-hmac@^1.1.0, create-hmac@^1.1.4, create-hmac@^1.1.7:
     safe-buffer "^5.0.1"
     sha.js "^2.4.8"
 
-cross-fetch@3.0.6:
+cross-fetch@3.0.6, cross-fetch@^3.0.6:
   version "3.0.6"
   resolved "https://registry.yarnpkg.com/cross-fetch/-/cross-fetch-3.0.6.tgz#3a4040bc8941e653e0e9cf17f29ebcd177d3365c"
   integrity sha512-KBPUbqgFjzWlVcURG+Svp9TlhA5uliYtiNx/0r8nv0pdypeQCRJ9IaSIc3q/x3q8t3F75cHuwxVql1HFGHCNJQ==
@@ -1824,6 +1841,11 @@ domutils@^2.4.2:
     domelementtype "^2.0.1"
     domhandler "^4.0.0"
 
+dotenv@^8.2.0:
+  version "8.2.0"
+  resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-8.2.0.tgz#97e619259ada750eea3e4ea3e26bceea5424b16a"
+  integrity sha512-8sJ78ElpbDJBHNeBzUbUVLsqKdccaa/BXF1uPTw3GrvQTBgrQrtObr2mUrE38vzYd8cEv+m/JBfDLioYcfXoaw==
+
 electron-to-chromium@^1.3.634:
   version "1.3.652"
   resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.652.tgz#9465d884d609acffd131ba71096de7bfabd63670"
@@ -1934,6 +1956,21 @@ fast-deep-equal@^1.0.0:
   resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz#c053477817c86b51daa853c81e059b733d023614"
   integrity sha1-wFNHeBfIa1HaqFPIHgWbcz0CNhQ=
 
+faunadb@4.1.1:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/faunadb/-/faunadb-4.1.1.tgz#c505aae1171abb18b7e8bf98bfe6b7bc1785e446"
+  integrity sha512-ekHtUgt+heYbaZXMWMB00Q7+DCiPKAubs2zbpNc4oMKamRxbL39MyzdNQNnCcSGOAJcLHPJbgOlDHK4y0Rkwrw==
+  dependencies:
+    abort-controller "^3.0.0"
+    base64-js "^1.2.0"
+    browser-detect "^0.2.28"
+    btoa-lite "^1.0.0"
+    cross-fetch "^3.0.6"
+    dotenv "^8.2.0"
+    fn-annotate "^1.1.3"
+    object-assign "^4.1.0"
+    util-deprecate "^1.0.2"
+
 fill-range@^7.0.1:
   version "7.0.1"
   resolved "https://registry.yarnpkg.com/fill-range/-/fill-range-7.0.1.tgz#1919a6a7c75fe38b2c7c77e5198535da9acdda40"
@@ -1962,6 +1999,11 @@ find-up@^4.0.0:
   dependencies:
     locate-path "^5.0.0"
     path-exists "^4.0.0"
+
+fn-annotate@^1.1.3:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/fn-annotate/-/fn-annotate-1.2.0.tgz#28da000117dea61842fe61f353f41cf4c93a7a7e"
+  integrity sha1-KNoAARfephhC/mHzU/Qc9Mk6en4=
 
 focus-lock@^0.7.0:
   version "0.7.0"
@@ -3771,7 +3813,7 @@ use-subscription@1.5.1:
   dependencies:
     object-assign "^4.1.1"
 
-util-deprecate@^1.0.1, util-deprecate@~1.0.1:
+util-deprecate@^1.0.1, util-deprecate@^1.0.2, util-deprecate@~1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/util-deprecate/-/util-deprecate-1.0.2.tgz#450d4dc9fa70de732762fbd2d4a28981419a0ccf"
   integrity sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=


### PR DESCRIPTION
Adding real-time database updates (pub/sub) using FaunaDB.

The whole app uses the same record/document in the `Canvas` collection for the sake of simplicity. (id: `1`)

![image](https://user-images.githubusercontent.com/3807458/110040474-2f03ef80-7d43-11eb-82fa-f57b434880d0.png)

Anyone doing any change will reflect in real-time to every subscriber.

To test this PR, you can go to https://poc-nextjs-reaflow-git-poc-faunadb-ambroise-dhenain.vercel.app with 2 tabs open.

PR review is welcome, especially regarding FaunaDB best practices and FQL. I've literally started with FaunaDB this morning, got a lot to learn.


FaunaDB doc: https://docs.fauna.com/fauna/current/

🎉 


---

**Upcoming in another PR**: Implementing an auth system, so each user can have their own project if they're authenticated. If not authenticated, then will use the shared project.

This is gonna be a bit more complicated (relying more on FaunaDB internals, ABAC, FQL, etc.)